### PR TITLE
Update usage of ContractManager

### DIFF
--- a/monitoring_service/__main__.py
+++ b/monitoring_service/__main__.py
@@ -9,6 +9,7 @@ from monitoring_service.state_db import StateDB
 from monitoring_service.api.rest import ServiceApi
 from monitoring_service.blockchain import BlockchainMonitor
 from raiden_libs.no_ssl_patch import no_ssl_verification
+from raiden_contracts.contract_manager import ContractManager, contracts_source_path
 
 
 @click.command()
@@ -87,8 +88,10 @@ def main(
     web3 = Web3(HTTPProvider(eth_rpc))
     blockchain = BlockchainMonitor(web3)
     db = StateDB(state_db)
+    contract_manager = ContractManager(contracts_source_path())
 
     monitor = MonitoringService(
+        contract_manager,
         private_key,
         state_db=db,
         transport=transport,

--- a/monitoring_service/blockchain.py
+++ b/monitoring_service/blockchain.py
@@ -1,17 +1,18 @@
 import logging
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import ContractManager, contracts_source_path
 from raiden_libs.utils import decode_contract_call
 from raiden_libs.blockchain import BlockchainListener
 from typing import Callable
 
 log = logging.getLogger(__name__)
+contract_manager = ContractManager(contracts_source_path())
 
 
 class BlockchainMonitor(BlockchainListener):
     def __init__(self, web3, **kwargs) -> None:
         super().__init__(
             web3,
-            CONTRACT_MANAGER,
+            contract_manager,
             'TokenNetwork',
             poll_interval=1,
             **kwargs
@@ -27,7 +28,7 @@ class BlockchainMonitor(BlockchainListener):
     def handle_event(self, event, callback: Callable):
         tx = self.web3.eth.getTransaction(event['transactionHash'])
         log.info(str(event) + str(tx))
-        abi = CONTRACT_MANAGER.get_contract_abi('TokenNetwork')
+        abi = contract_manager.get_contract_abi('TokenNetwork')
         assert abi is not None
         method_params = decode_contract_call(abi, tx['data'])
         if method_params is not None:

--- a/monitoring_service/test/fixtures/contracts.py
+++ b/monitoring_service/test/fixtures/contracts.py
@@ -1,21 +1,13 @@
 import pytest
 import logging
-from raiden_contracts.contract_manager import (
-    ContractManager,
-    CONTRACTS_SOURCE_DIRS,
-)
+from raiden_contracts.contract_manager import ContractManager, contracts_source_path
 
 log = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def contracts_source_dir():
-    return CONTRACTS_SOURCE_DIRS
-
-
-@pytest.fixture
-def contracts_manager(contracts_source_dir):
-    return ContractManager(contracts_source_dir)
+def contracts_manager():
+    return ContractManager(contracts_source_path())
 
 
 @pytest.fixture

--- a/monitoring_service/test/fixtures/server.py
+++ b/monitoring_service/test/fixtures/server.py
@@ -39,12 +39,14 @@ def monitoring_service(
         state_db_mock,
         web3,
         monitoring_service_contract,
-        send_funds
+        send_funds,
+        contracts_manager
 ):
     # send some eth & tokens to MS
     send_funds(private_key_to_address(server_private_key))
     register_service(
         web3,
+        contracts_manager,
         monitoring_service_contract.address,
         server_private_key
     )
@@ -54,7 +56,8 @@ def monitoring_service(
         transport=dummy_transport,
         blockchain=blockchain,
         state_db=state_db_mock,
-        monitor_contract_address=monitoring_service_contract.address
+        monitor_contract_address=monitoring_service_contract.address,
+        contract_manager=contracts_manager,
     )
     yield ms
     ms.stop()

--- a/monitoring_service/test/test_e2e.py
+++ b/monitoring_service/test/test_e2e.py
@@ -1,15 +1,14 @@
 import gevent
 import pytest
 from raiden_libs.blockchain import BlockchainListener
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
 import logging
 
 
 class Validator(BlockchainListener):
-    def __init__(self, web3):
+    def __init__(self, web3, contracts_manager):
         super().__init__(
             web3,
-            CONTRACT_MANAGER,
+            contracts_manager,
             'MonitoringService',
             poll_interval=1
         )
@@ -23,8 +22,8 @@ class Validator(BlockchainListener):
 
 
 @pytest.fixture
-def blockchain_validator(web3):
-    validator = Validator(web3)
+def blockchain_validator(web3, contracts_manager):
+    validator = Validator(web3, contracts_manager)
     validator.start()
     yield validator
     validator.stop()

--- a/monitoring_service/test/unit/test_blockchain.py
+++ b/monitoring_service/test/unit/test_blockchain.py
@@ -3,7 +3,6 @@ from monitoring_service.constants import (
     EVENT_CHANNEL_CLOSE,
     EVENT_CHANNEL_SETTLED
 )
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
 from raiden_libs.utils import make_filter
 from eth_utils import encode_hex
 
@@ -58,7 +57,7 @@ def test_blockchain(generate_raiden_client, blockchain, wait_for_blocks):
     assert t.trigger_count == 2
 
 
-def test_filter(generate_raiden_client, web3):
+def test_filter(generate_raiden_client, web3, contracts_manager):
     """test if filter returns past events"""
     c1 = generate_raiden_client()
     c2 = generate_raiden_client()
@@ -69,7 +68,7 @@ def test_filter(generate_raiden_client, web3):
     c1.close_channel(c2.address, bp)
     gevent.sleep(0)
 
-    abi = CONTRACT_MANAGER.get_event_abi('TokenNetwork', 'ChannelClosed')
+    abi = contracts_manager.get_event_abi('TokenNetwork', 'ChannelClosed')
     assert abi is not None
     f = make_filter(web3, abi, fromBlock=0)
     entries = f.get_new_entries()

--- a/monitoring_service/test/unit/test_server.py
+++ b/monitoring_service/test/unit/test_server.py
@@ -17,7 +17,8 @@ def test_server_registration(
         web3,
         standard_token_contract,
         monitoring_service_contract,
-        send_funds
+        send_funds,
+        contracts_manager
 ):
     """Test two scenarios - instantiating a non-registered server (this should fail),
     and registering it and instantiating again"""
@@ -28,24 +29,30 @@ def test_server_registration(
             transport=dummy_transport,
             blockchain=blockchain,
             state_db=state_db_mock,
-            monitor_contract_address=monitoring_service_contract.address
+            monitor_contract_address=monitoring_service_contract.address,
+            contract_manager=contracts_manager,
         )
 
     # give some tokens to the MS
     server_address = private_key_to_address(server_private_key)
     send_funds(server_address)
     # register MS
-    register_service(web3, monitoring_service_contract.address, server_private_key)
+    register_service(
+        web3, contracts_manager, monitoring_service_contract.address, server_private_key
+    )
 
     # check if registration succeeded
-    assert is_service_registered(web3, monitoring_service_contract.address, server_address) is True
+    assert is_service_registered(
+        web3, contracts_manager, monitoring_service_contract.address, server_address
+    )
     # now instantiation will proceed
     ms = MonitoringService(
         server_private_key,
         transport=dummy_transport,
         blockchain=blockchain,
         state_db=state_db_mock,
-        monitor_contract_address=monitoring_service_contract.address
+        monitor_contract_address=monitoring_service_contract.address,
+        contract_manager=contracts_manager,
     )
     assert ms is not None
 
@@ -57,11 +64,14 @@ def test_server_wrong_db(
         web3,
         monitoring_service_contract,
         get_random_address,
-        send_funds
+        send_funds,
+        contracts_manager
 ):
     server_address = private_key_to_address(server_private_key)
     send_funds(server_address)
-    register_service(web3, monitoring_service_contract.address, server_private_key)
+    register_service(
+        web3, contracts_manager, monitoring_service_contract.address, server_private_key
+    )
 
     def create_server(setup_database):
         db = StateDBMock()
@@ -71,7 +81,8 @@ def test_server_wrong_db(
             transport=dummy_transport,
             blockchain=blockchain,
             state_db=db,
-            monitor_contract_address=monitoring_service_contract.address
+            monitor_contract_address=monitoring_service_contract.address,
+            contract_manager=contracts_manager,
         )
     with pytest.raises(StateDBInvalid):
         create_server(

--- a/monitoring_service/tools/register_ms.py
+++ b/monitoring_service/tools/register_ms.py
@@ -16,17 +16,20 @@ def validate_address(ctx, param, value):
 
 def monitor_registration(
         web3: Web3,
+        contract_manager,
         ms_contract_address,
         monitoring_service_address,
         private_key
 ):
-    if is_service_registered(web3, ms_contract_address, monitoring_service_address) is True:
+    if is_service_registered(
+        web3, contract_manager, ms_contract_address, monitoring_service_address
+    ):
         log.error(
             'MS service %s is already registered in the contract %s' %
             (ms_contract_address, monitoring_service_address)
         )
         return False
-    return register_service(web3, ms_contract_address, private_key)
+    return register_service(web3, contract_manager, ms_contract_address, private_key)
 
 
 @click.command()

--- a/monitoring_service/utils.py
+++ b/monitoring_service/utils.py
@@ -1,6 +1,5 @@
 from eth_utils import is_checksum_address, to_checksum_address
 from web3 import Web3
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
 from raiden_libs.private_contract import PrivateContract
 from raiden_libs.utils import private_key_to_address
 from web3.utils.transactions import wait_for_transaction_receipt
@@ -8,15 +7,16 @@ from web3.utils.transactions import wait_for_transaction_receipt
 
 def is_service_registered(
     web3: Web3,
+    contract_manager,
     msc_contract_address: str,
     service_address: str
 ) -> bool:
     """Returns true if service is registered in the Monitoring service contract"""
     assert is_checksum_address(msc_contract_address)
     assert is_checksum_address(service_address)
-    monitor_contract_abi = CONTRACT_MANAGER.get_contract_abi('MonitoringService')
+    monitor_contract_abi = contract_manager.get_contract_abi('MonitoringService')
     monitor_contract = web3.eth.contract(abi=monitor_contract_abi, address=msc_contract_address)
-    bundle_contract_abi = CONTRACT_MANAGER.get_contract_abi('RaidenServiceBundle')
+    bundle_contract_abi = contract_manager.get_contract_abi('RaidenServiceBundle')
     raiden_service_bundle_address = to_checksum_address(monitor_contract.functions.rsb().call())
     bundle_contract = web3.eth.contract(
         abi=bundle_contract_abi,
@@ -27,6 +27,7 @@ def is_service_registered(
 
 def register_service(
     web3: Web3,
+    contract_manager,
     msc_contract_address: str,
     private_key: str,
     deposit: int = 10  # any amount works now
@@ -35,12 +36,12 @@ def register_service(
     service_address = private_key_to_address(private_key)
     assert is_checksum_address(msc_contract_address)
     assert is_checksum_address(service_address)
-    monitor_contract_abi = CONTRACT_MANAGER.get_contract_abi('MonitoringService')
+    monitor_contract_abi = contract_manager.get_contract_abi('MonitoringService')
     monitor_contract = PrivateContract(web3.eth.contract(
         abi=monitor_contract_abi,
         address=msc_contract_address
     ))
-    bundle_contract_abi = CONTRACT_MANAGER.get_contract_abi('RaidenServiceBundle')
+    bundle_contract_abi = contract_manager.get_contract_abi('RaidenServiceBundle')
     raiden_service_bundle_address = to_checksum_address(monitor_contract.functions.rsb().call())
     bundle_contract = PrivateContract(web3.eth.contract(
         abi=bundle_contract_abi,
@@ -49,7 +50,7 @@ def register_service(
 
     # approve funds for MSC
     token_address = to_checksum_address(monitor_contract.functions.token().call())
-    token_abi = CONTRACT_MANAGER.get_contract_abi('Token')
+    token_abi = contract_manager.get_contract_abi('Token')
     token_contract = web3.eth.contract(abi=token_abi, address=token_address)
     token_contract = PrivateContract(token_contract)
     tx = token_contract.functions.approve(raiden_service_bundle_address, deposit).transact(


### PR DESCRIPTION
The usage of raiden_contracts.contract_manager has changed and the
monitoring service need these changes to make the tests passe.
Passing around the ContractManager instance everywhere is not beautiful,
but it's consistent with use usage of the web3 instance.