### PR TITLE
Save syncstate

### DIFF
--- a/monitoring_service/server.py
+++ b/monitoring_service/server.py
@@ -71,6 +71,9 @@ class MonitoringService(gevent.Greenlet):
             sync_start_block,
             required_confirmations,
             poll_interval,
+            load_syncstate=state_db.load_syncstate,
+            save_syncstate=state_db.save_syncstate,
+            get_synced_contracts=state_db.get_synced_contracts,
         )
         self.token_network_listener.add_confirmed_channel_event_listener(
             self.on_channel_event,

--- a/monitoring_service/state_db/__init__.py
+++ b/monitoring_service/state_db/__init__.py
@@ -1,5 +1,6 @@
-from .sqlite_db import StateDBSqlite
+from .sqlite_db import StateDBSqlite, SqliteStateHandler
 
 __all__ = [
     'StateDBSqlite',
+    'SqliteStateHandler',
 ]

--- a/monitoring_service/state_db/schema.sql
+++ b/monitoring_service/state_db/schema.sql
@@ -10,16 +10,11 @@ INSERT INTO metadata VALUES (
 );
 
 CREATE TABLE syncstate (
-    confirmed_head_number   INTEGER,
-    confirmed_head_hash     CHAR(66),
-    unconfirmed_head_number INTEGER,
-    unconfirmed_head_hash   CHAR(66)
-);
-INSERT INTO syncstate VALUES (
-    NULL,
-    NULL,
-    NULL,
-    NULL
+    contract_address        CHAR(42) PRIMARY KEY,
+    confirmed_head_number   INTEGER NOT NULL,
+    confirmed_head_hash     CHAR(66) NOT NULL,
+    unconfirmed_head_number INTEGER NOT NULL,
+    unconfirmed_head_hash   CHAR(66) NOT NULL
 );
 
 CREATE TABLE channels (

--- a/monitoring_service/state_db/sqlite_db.py
+++ b/monitoring_service/state_db/sqlite_db.py
@@ -208,6 +208,6 @@ class SqliteStateHandler(BlockchainListenerStateHandler):
         # self.conn.execute('BEGIN EXCLUSIVE')
         pass
 
-    def commit(self, _) -> None:  # TODO
+    def commit(self) -> None:  # TODO
         # self.conn.commit()
         pass

--- a/monitoring_service/tests/fixtures/monitor_request.py
+++ b/monitoring_service/tests/fixtures/monitor_request.py
@@ -12,14 +12,14 @@ def get_monitor_request_for_same_channel(
         get_random_address,
         get_random_privkey,
         token_network,
-        state_db_sqlite,
+        state_handler,
 ):
     keys = [get_random_privkey() for i in range(3)]
     token_network_address = token_network.address
 
     channel_id = 1
     balance_hash_data = '0'
-    state_db_sqlite.store_new_channel(
+    state_handler.store_new_channel(
         channel_id,
         token_network_address,
         private_key_to_address(keys[0]),

--- a/monitoring_service/tests/fixtures/state_db.py
+++ b/monitoring_service/tests/fixtures/state_db.py
@@ -1,6 +1,8 @@
+import os
+
 import pytest
 
-from monitoring_service.state_db import StateDBSqlite
+from monitoring_service.state_db import SqliteStateHandler, StateDBSqlite
 from raiden_libs.utils import private_key_to_address
 
 
@@ -9,11 +11,20 @@ def state_db_sqlite(
     get_random_address,
     server_private_key,
     monitoring_service_contract,
+    tmpdir,
 ):
-    state_db_sqlite = StateDBSqlite(':memory:')
+    state_db_sqlite = StateDBSqlite(os.path.join(tmpdir, 'state.sqlite3'))
     state_db_sqlite.setup_db(
         1,
         monitoring_service_contract.address,
         private_key_to_address(server_private_key),
     )
     return state_db_sqlite
+
+
+@pytest.fixture
+def state_handler(
+    state_db_sqlite,
+    custom_token,
+):
+    return SqliteStateHandler(state_db_sqlite.get_conn(), custom_token.address)

--- a/monitoring_service/tests/test_state_db.py
+++ b/monitoring_service/tests/test_state_db.py
@@ -1,6 +1,13 @@
-def test_state_db_sqlite(state_db_sqlite, get_random_monitor_request, get_random_address):
+
+
+def test_state_db_sqlite(
+    state_db_sqlite,
+    state_handler,
+    get_random_monitor_request,
+    get_random_address,
+):
     request = get_random_monitor_request()
-    state_db_sqlite.store_new_channel(
+    state_handler.store_new_channel(
         request.balance_proof.channel_identifier,
         request.balance_proof.token_network_address,
         request.balance_proof.signer,

--- a/monitoring_service/tests/test_token_network_listener.py
+++ b/monitoring_service/tests/test_token_network_listener.py
@@ -1,6 +1,7 @@
 import gevent
 import pytest
 
+from monitoring_service.state_db import SqliteStateHandler
 from monitoring_service.token_network_listener import TokenNetworkListener
 
 
@@ -11,6 +12,9 @@ def get_token_network_listener(
     token_network_registry_contract,
     state_db_sqlite,
 ):
+    def get_state_handler(contract_address):
+        return SqliteStateHandler(state_db_sqlite.get_conn(), contract_address)
+
     def get():
         return TokenNetworkListener(
             web3,
@@ -19,8 +23,7 @@ def get_token_network_listener(
             sync_start_block=0,
             required_confirmations=1,
             poll_interval=0.001,
-            load_syncstate=state_db_sqlite.load_syncstate,
-            save_syncstate=state_db_sqlite.save_syncstate,
+            get_state_handler=get_state_handler,
             get_synced_contracts=state_db_sqlite.get_synced_contracts,
         )
     return get

--- a/monitoring_service/tests/test_token_network_listener.py
+++ b/monitoring_service/tests/test_token_network_listener.py
@@ -1,0 +1,87 @@
+import gevent
+import pytest
+
+from monitoring_service.token_network_listener import TokenNetworkListener
+
+
+@pytest.fixture
+def get_token_network_listener(
+    web3,
+    contracts_manager,
+    token_network_registry_contract,
+    state_db_sqlite,
+):
+    def get():
+        return TokenNetworkListener(
+            web3,
+            contracts_manager,
+            registry_address=token_network_registry_contract.address,
+            sync_start_block=0,
+            required_confirmations=1,
+            poll_interval=0.001,
+            load_syncstate=state_db_sqlite.load_syncstate,
+            save_syncstate=state_db_sqlite.save_syncstate,
+            get_synced_contracts=state_db_sqlite.get_synced_contracts,
+        )
+    return get
+
+
+def test_syncstate_registry(
+    web3,
+    state_db_sqlite,
+    wait_for_blocks,
+    get_token_network_listener,
+):
+    """ Test saving and loading of syncstate """
+    old_head = web3.eth.blockNumber
+    token_network_listener = get_token_network_listener()
+    token_network_listener.start()
+    wait_for_blocks(2)
+    gevent.sleep(0.1)
+    syncstates = state_db_sqlite.conn.execute("SELECT * FROM syncstate").fetchall()
+    assert len(syncstates) == 1
+    syncstate = syncstates[0]
+    assert syncstate['unconfirmed_head_number'] == old_head + 2
+    assert syncstate['confirmed_head_number'] == old_head + 1
+    token_network_listener.stop()
+
+    token_network_listener = get_token_network_listener()
+    listener = token_network_listener.token_network_registry_listener
+    assert listener.confirmed_head_number == syncstate['confirmed_head_number']
+    assert listener.confirmed_head_hash == syncstate['confirmed_head_hash']
+    assert listener.unconfirmed_head_number == syncstate['unconfirmed_head_number']
+    assert listener.unconfirmed_head_hash == syncstate['unconfirmed_head_hash']
+
+
+def test_syncstate_token_network(
+    web3,
+    state_db_sqlite,
+    wait_for_blocks,
+    get_token_network_listener,
+    register_token_network,
+    custom_token,
+    token_network_registry_contract,
+):
+    """ Test saving and loading of syncstate """
+    token_network_listener = get_token_network_listener()
+    token_network_listener.start()
+    register_token_network(custom_token.address)
+    old_head = web3.eth.blockNumber
+    wait_for_blocks(2)
+    gevent.sleep(0.1)
+    syncstates = state_db_sqlite.conn.execute(
+        "SELECT * FROM syncstate WHERE contract_address != ?",
+        [token_network_registry_contract.address],
+    ).fetchall()
+    assert len(syncstates) == 1
+    syncstate = syncstates[0]
+    assert syncstate['unconfirmed_head_number'] == old_head + 2
+    assert syncstate['confirmed_head_number'] == old_head + 1
+    token_network_listener.stop()
+
+    token_network_listener = get_token_network_listener()
+    listener = token_network_listener.token_network_listeners[0]
+    assert listener.confirmed_head_number == syncstate['confirmed_head_number']
+    assert listener.confirmed_head_hash == syncstate['confirmed_head_hash']
+    assert listener.unconfirmed_head_number == syncstate['unconfirmed_head_number']
+    assert listener.unconfirmed_head_hash == syncstate['unconfirmed_head_hash']

--- a/monitoring_service/utils/__init__.py
+++ b/monitoring_service/utils/__init__.py
@@ -7,12 +7,14 @@ from raiden_libs.utils import private_key_to_address
 from raiden_contracts.constants import CONTRACT_MONITORING_SERVICE, CONTRACT_RAIDEN_SERVICE_BUNDLE
 from raiden_contracts.contract_manager import ContractManager
 
-
-from .blockchain_listener import BlockchainListener, BlockchainMonitor
+from .blockchain_listener import (
+    BlockchainListener, BlockchainMonitor, BlockchainListenerStateHandler,
+)
 
 __all__ = [
     'BlockchainListener',
     'BlockchainMonitor',
+    'BlockchainListenerStateHandler',
 ]
 
 

--- a/monitoring_service/utils/blockchain_listener.py
+++ b/monitoring_service/utils/blockchain_listener.py
@@ -146,7 +146,6 @@ class BlockchainListener(gevent.Greenlet):
 
         self.confirmed_callbacks: Dict[int, Tuple[List, Callable]] = {}
         self.unconfirmed_callbacks: Dict[int, Tuple[List, Callable]] = {}
-        self.chunk_callbacks: List[Callable] = []
         self.state_handler = state_handler
 
         self.wait_sync_event = gevent.event.Event()
@@ -178,14 +177,6 @@ class BlockchainListener(gevent.Greenlet):
         """ Add a callback to listen for unconfirmed events. """
         self.unconfirmed_callbacks[self.counter] = (topics, callback)
         self.counter += 1
-
-    def add_chunk_callback(self, callback: Callable):
-        """ Trigger callback after processing a chunk of blocks.
-
-        This is useful to save the processing state to disk. The callback gets
-        called the BlockchainListener as argument.
-        """
-        self.chunk_callbacks.append(callback)
 
     def _run(self):
         self.running = True

--- a/monitoring_service/utils/blockchain_listener.py
+++ b/monitoring_service/utils/blockchain_listener.py
@@ -28,10 +28,10 @@ class BlockchainListenerStateHandler:
     def save_syncstate(self, blockchain_listener: 'BlockchainListener'):
         pass
 
-    def begin(self) -> None:  # TODO
+    def begin(self) -> None:
         pass
 
-    def commit(self, _) -> None:  # TODO
+    def commit(self) -> None:
         """ Gets called when a consistent state is reached """
         pass
 
@@ -285,7 +285,7 @@ class BlockchainListener(gevent.Greenlet):
 
         # work state is consistent -> commit
         self.state_handler.save_syncstate(self)
-        self.state_handler.commit(None)
+        self.state_handler.commit()
 
         if not self.wait_sync_event.is_set() and new_unconfirmed_head_number == current_block:
             self.wait_sync_event.set()

--- a/request_collector/tests/test_store_monitor_request.py
+++ b/request_collector/tests/test_store_monitor_request.py
@@ -51,7 +51,6 @@ def test_request_validation(
 def test_save_mr_from_transport(
     request_collector,
     get_monitor_request_for_same_channel,
-    state_db_sqlite,
 ):
     """Does the request collector save submitted MRs?"""
     monitor_request = get_monitor_request_for_same_channel(user=0)


### PR DESCRIPTION
This PR achieves
* saving and reloading of sync states
* using separate connections each greenlet

But there's still work to do:
- [ ] Avoid database locks by splitting the data into different databases, then turn on transactions
- [ ] Clean up separation between `StateDBSqlite` and `SQLiteStateHandler`
- [ ] Proper handling of start_block for newly detected token networks

The current state can be reviewed with this in mind and merged, since it is already an improvement.

Relates to #37.